### PR TITLE
Potential fix for code scanning alert no. 58: Missing rate limiting

### DIFF
--- a/docs/recipes/auth/package.json
+++ b/docs/recipes/auth/package.json
@@ -6,6 +6,7 @@
     "express": "^4.17.1",
     "express-session": "^1.16.2",
     "lighthouse": "file:../../../dist/lighthouse.tgz",
-    "morgan": "^1.9.1"
+    "morgan": "^1.9.1",
+    "express-rate-limit": "^7.5.0"
   }
 }

--- a/docs/recipes/auth/server/server.js
+++ b/docs/recipes/auth/server/server.js
@@ -16,9 +16,19 @@ const morgan = require('morgan');
 const session = require('express-session');
 const http = require('http');
 const path = require('path');
+const RateLimit = require('express-rate-limit');
 const PUBLIC_DIR = path.join(__dirname, 'public');
 
 const app = express();
+
+// set up rate limiter: maximum of 100 requests per 15 minutes
+const limiter = RateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 100, // max 100 requests per windowMs
+});
+
+// apply rate limiter to all requests
+app.use(limiter);
 
 app.use(morgan('dev'));
 app.use(express.urlencoded({extended: false}));


### PR DESCRIPTION
Potential fix for [https://github.com/Dimvy-Clothing-brand/lighthouse/security/code-scanning/58](https://github.com/Dimvy-Clothing-brand/lighthouse/security/code-scanning/58)

To fix the problem, we need to introduce rate limiting to the Express application. The best way to do this is by using the `express-rate-limit` middleware, which allows us to set a maximum number of requests that a client can make within a specified time window. This will help prevent abuse and mitigate the risk of denial-of-service attacks.

We will:
1. Install the `express-rate-limit` package.
2. Import the `express-rate-limit` package in the `docs/recipes/auth/server/server.js` file.
3. Set up a rate limiter with appropriate configuration (e.g., maximum of 100 requests per 15 minutes).
4. Apply the rate limiter to all routes in the application.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
