### PR TITLE
Potential fix for code scanning alert no. 48: Missing CSRF middleware

### DIFF
--- a/docs/recipes/auth/package.json
+++ b/docs/recipes/auth/package.json
@@ -6,6 +6,7 @@
     "express": "^4.17.1",
     "express-session": "^1.16.2",
     "lighthouse": "file:../../../dist/lighthouse.tgz",
-    "morgan": "^1.9.1"
+    "morgan": "^1.9.1",
+    "lusca": "^1.7.0"
   }
 }

--- a/docs/recipes/auth/server/server.js
+++ b/docs/recipes/auth/server/server.js
@@ -16,6 +16,7 @@ const morgan = require('morgan');
 const session = require('express-session');
 const http = require('http');
 const path = require('path');
+const csrf = require('lusca').csrf;
 const PUBLIC_DIR = path.join(__dirname, 'public');
 
 const app = express();
@@ -28,6 +29,7 @@ app.use(session({
   resave: true,
   saveUninitialized: false,
 }));
+app.use(csrf());
 
 app.get('/dashboard', (req, res) => {
   if (req.session.user) {


### PR DESCRIPTION
Potential fix for [https://github.com/Dimvy-Clothing-brand/lighthouse/security/code-scanning/48](https://github.com/Dimvy-Clothing-brand/lighthouse/security/code-scanning/48)

To fix the issue, we need to add CSRF protection middleware to the Express application. The `lusca` package provides a convenient way to add CSRF protection. We will install the `lusca` package and use its CSRF middleware in the Express application. This involves the following steps:

1. Install the `lusca` package.
2. Import the `lusca` package in the `docs/recipes/auth/server/server.js` file.
3. Add the CSRF middleware to the Express application.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
