### PR TITLE
Potential fix for code scanning alert no. 28: Client-side cross-site scripting

### DIFF
--- a/lighthouse-cli/test/fixtures/js-redirect.html
+++ b/lighthouse-cli/test/fixtures/js-redirect.html
@@ -9,8 +9,9 @@
       }
 
       const params = new URLSearchParams(window.location.search);
-      const delay = params.get('jsDelay') || 3000;
-      const redirect = params.get('jsRedirect') || '/redirects-final.html';
+      const delay = parseInt(params.get('jsDelay')) || 3000;
+      const allowedRedirects = ['/redirects-final.html', '/another-allowed.html'];
+      const redirect = allowedRedirects.includes(params.get('jsRedirect')) ? params.get('jsRedirect') : '/redirects-final.html';
 
       if (params.get('noFcp')) {
         // If we don't want an FCP then stall and redirect synchronously
@@ -23,7 +24,8 @@
   <body>
     Redirecting in
     <script>
-      document.write(` ${delay}ms...`);
+      const delayText = document.createTextNode(` ${delay}ms...`);
+      document.body.appendChild(delayText);
       // Redirect to the location in jsDelay milliseconds.
       setTimeout(() => window.location = redirect, delay);
       // Create a long task every 400ms to prevent Lighthouse from moving on


### PR DESCRIPTION
Potential fix for [https://github.com/Dimvy-Clothing-brand/lighthouse/security/code-scanning/28](https://github.com/Dimvy-Clothing-brand/lighthouse/security/code-scanning/28)

To fix the problem, we need to ensure that the `redirect` value is properly sanitized before it is used. One way to do this is to use a whitelist of allowed URLs or to encode the URL to prevent XSS attacks. Additionally, we should avoid using `document.write` and instead use safer methods to update the DOM.

The best way to fix the problem without changing existing functionality is to use a whitelist approach for the `redirect` URL and to update the DOM using safer methods. We will also sanitize the `delay` value to ensure it is a valid number.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
